### PR TITLE
Add lastmod to build options

### DIFF
--- a/api.md
+++ b/api.md
@@ -99,6 +99,7 @@ Convert array of paths to sitemap.
 -   `hostname` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The root name of your site.
 -   `$1` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
     -   `$1.limitCountPaths`   (optional, default `49999`)
+    -   `$1.lastMod` **[Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) or string that can be evaluated as a date**   (optional) adds `<lastmod>` tag to all of the paths set to the date value passed
 
 ## save
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,10 +109,10 @@ class Sitemap {
 	 * @description Convert array of paths to sitemap.
 	 * @param {String} hostname - The root name of your site.
 	 */
-	build(hostname, { limitCountPaths = 49999 } = {}) {
+	build(hostname, { limitCountPaths = 49999, lastMod } = {}) {
 		this.hostname = hostname;
 		this.splitted = splitPaths(this.paths, limitCountPaths);
-		this.sitemaps = this.splitted.map(paths => buildSitemap(hostname, paths));
+		this.sitemaps = this.splitted.map(paths => buildSitemap(hostname, paths, lastMod));
 		return this;
 	}
 

--- a/lib/sitemap-builder/index.js
+++ b/lib/sitemap-builder/index.js
@@ -14,11 +14,12 @@ import sitemap from 'sitemap';
  * const hostname = 'http://may-site.ru';
  * const sitemap = buildSitemap(hostname, paths);
  */
-export default (hostname = 'http://localhost', paths = []) => {
+export default (hostname = 'http://localhost', paths = [], lastmod) => {
 
 	return sitemap.createSitemap({
 		hostname,
-		urls: paths.map(path => ({ url: path })),
+		urls: paths.map(path => ({ url: path, lastmod })),
+		lastmod,
 	});
 
 };


### PR DESCRIPTION
Allows you to include an optional property `lastmod` in the options param passed to `Sitemap.build(paths, options)`. `lastMod` should be a date (or string that can be evaluated as a date). That date will then be included on all paths in a `<lastmod>` tag.