### PR TITLE
Update React Router peer dependency to be v4/5 instead of v2/3/4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "react": "^15.1.0 || ^16.0.0",
-    "react-router": "^2.3.0 || ^3.2.1 || ^4.3.0"
+    "react-router": "^4.3.0 || ^5.2.0"
   },
   "dependencies": {
     "sitemap": "^1.6.0"


### PR DESCRIPTION
want to use React Router v5, so i added it as a peer dependency and removed v2 and v3, which are quite old. continues to work with the developer portal.